### PR TITLE
Update dependentdropdownfield.js

### DIFF
--- a/javascript/dependentdropdownfield.js
+++ b/javascript/dependentdropdownfield.js
@@ -3,7 +3,7 @@ jQuery.entwine("dependentdropdown", function($) {
 	$(":input.dependent-dropdown").entwine({
 		onmatch: function() {
 			var drop = this;
-			var depends = ($(":input[name=" + drop.data('depends') + "]"));
+			var depends = ($(":input[name=" + drop.data('depends').replace(/[#;&,.+*~':"!^$[\]()=>|\/]/g, "\\$&") + "]"));
 
 			this.parents('.field:first').addClass('dropdown');
 


### PR DESCRIPTION
This seems to fix situations where the field name has [] or other meta characters in it.
For example Reports module likes to namespace field names with "filter[$Name]"
