### PR TITLE
FIX Item ordering and css class setting

### DIFF
--- a/code/DependentDropdownField.php
+++ b/code/DependentDropdownField.php
@@ -13,13 +13,28 @@ class DependentDropdownField extends DropdownField {
 
 	protected $depends;
 	protected $unselected;
+	
+	
+	public function __construct($name, $title = null, $source = array(), $value = '', $form = null, $emptyString = null) {
+		parent::__construct($name, $title, $source, $value, $form, $emptyString);
+		
+		$this->addExtraClass('dependent-dropdown');
+		$this->addExtraClass('dropdown');
+	}
 
 	public function load($request) {
 		$response = new SS_HTTPResponse();
 		$response->addHeader('Content-Type', 'application/json');
-		$response->setBody(Convert::array2json(call_user_func(
-			$this->source, $request->getVar('val')
-		)));
+		
+		$items = call_user_func($this->source, $request->getVar('val'));
+		$results = array();
+		if ($items) {
+			foreach ($items as $k => $v) {
+				$results[] = array('k' => $k, 'v' => $v);
+			}
+		}
+		
+		$response->setBody(Convert::array2json($results));
 		return $response;
 	}
 
@@ -64,8 +79,6 @@ class DependentDropdownField extends DropdownField {
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
 		Requirements::javascript(DEPENDENTDROPDOWNFIELD . '/javascript/dependentdropdownfield.js');
 
-		$this->addExtraClass('dependent-dropdown');
-		$this->addExtraClass('dropdown');
 		$this->setAttribute('data-link', $this->Link('load'));
 		$this->setAttribute('data-depends', $this->getDepends()->getName());
 		$this->setAttribute('data-empty', $this->getEmptyString());

--- a/javascript/dependentdropdownfield.js
+++ b/javascript/dependentdropdownfield.js
@@ -20,8 +20,8 @@ jQuery.entwine("dependentdropdown", function($) {
 							drop.append($("<option />").val("").text(drop.data('empty')))
 						}
 
-						$.each(data, function(k, v) {
-							drop.append($("<option />").val(k).text(v))
+						$.each(data, function() {
+							drop.append($("<option />").val(this.k).text(this.v))
 						});
 						drop.trigger("liszt:updated");
 					});


### PR DESCRIPTION
- Swap to using explicit array return value for load() to ensure the ordering
  of items is preserved in webkit browsers, which don't iterate object key:vals
  in-order of definition in the obect.
- Move the css class additions to the constructor to allow them to be
  overridden by user code if desired