### PR TITLE
Add missing close bracket to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #silverstripe-dependentdropdownfield
 
-A silverstripe dropdown field that has it's options populated via ajax, based on the value of the field it depends on
+A SilverStripe dropdown field that has it's options populated via ajax, based on the value of the field it depends on.
 
 ##Requirements
 
@@ -12,20 +12,20 @@ SilverStripe 3
 // 1. Create a callable function that returns an array of options for the DependentDropdownField. 
 // When the value of the field it depends on changes, this function is called passing the 
 // updated value as the first parameter ($val)
-$datesSource = function($val){	
-	if($val == 'one'){
-	  // return appropriate options array if the value is one.
+$datesSource = function($val) {	
+	if ($val == 'one') {
+		// return appropriate options array if the value is one.
 	}
-	if($val == 'two'){
-	  // return appropriate options array if the value is two.
+	if ($val == 'two') {
+		// return appropriate options array if the value is two.
 	}
 }; 
 
 $fields = FieldList::create(
-  // 2. Add your first field to your field list, 
-	$fieldOne = DropdownField::create('FieldOne','Field One', array('one' => 'One', 'two' => 'Two'),
+	// 2. Add your first field to your field list, 
+	$fieldOne = DropdownField::create('FieldOne', 'Field One', array('one' => 'One', 'two' => 'Two')),
 	// 3. Add your DependentDropdownField, setting the source as the callable function 
 	// you created and setting the field it depends on to the appropriate field
-	DependentDropdownField::create('FieldTwo','Field Two', $datesSource)->setDepends($fieldOne)
+	DependentDropdownField::create('FieldTwo', 'Field Two', $datesSource)->setDepends($fieldOne)
 );
 ```


### PR DESCRIPTION
The DropdownField in the usage example was missing a close bracket. 

I've added in the close bracket so the example code works if anyone copies it. 

I've also made some very minor code formatting changes to the example code.