### PR TITLE
Trigger chosen:updated for newer versions of chosen

### DIFF
--- a/javascript/dependentdropdownfield.js
+++ b/javascript/dependentdropdownfield.js
@@ -26,7 +26,7 @@ jQuery.entwine("dependentdropdown", function ($) {
 						$.each(data, function () {
 							drop.append($("<option />").val(this.k).text(this.v));
 						});
-						drop.trigger("liszt:updated");
+						drop.trigger("liszt:updated").trigger("chosen:updated");
 					});
 				}
 			});
@@ -36,7 +36,7 @@ jQuery.entwine("dependentdropdown", function ($) {
 			}
 		},
 		disable: function (text) {
-			this.empty().append($("<option />").val("").text(text)).attr("disabled", "disabled").trigger("liszt:updated");
+			this.empty().append($("<option />").val("").text(text)).attr("disabled", "disabled").trigger("liszt:updated").trigger("chosen:updated");
 		},
 		enable: function () {
 			this.empty().removeAttr("disabled").next().removeClass('chzn-disabled');


### PR DESCRIPTION
Chosen no longer listens for "liszt:updated", but for "chosen:updated".

Please merge to make this work for current versions of chosen.

Could you please make this a new stable release so we don't have to work with dev-master when installing via composer?

Thank you!