### PR TITLE
FIX: castedCopy compliant

### DIFF
--- a/src/Forms/DependentDropdownField.php
+++ b/src/Forms/DependentDropdownField.php
@@ -153,6 +153,10 @@ class DependentDropdownField extends DropdownField
         }
     }
     
+     /**
+     * @param \Closure $source
+     * @return $this
+     */
     public function setSource($source)
     {
         $this->sourceCallback = $source;

--- a/src/Forms/DependentDropdownField.php
+++ b/src/Forms/DependentDropdownField.php
@@ -50,7 +50,7 @@ class DependentDropdownField extends DropdownField
      * @param $form
      * @param string $emptyString
      */
-    public function __construct($name, $title = null, \Closure $source, $value = '', $form = null, $emptyString = null)
+    public function __construct($name, $title = null, \Closure $source = null, $value = '', $form = null, $emptyString = null)
     {
         parent::__construct($name, $title, [], $value, $form, $emptyString);
 
@@ -151,6 +151,12 @@ class DependentDropdownField extends DropdownField
         } else {
             return $source;
         }
+    }
+    
+    public function setSource($source)
+    {
+        $this->sourceCallback = $source;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
 `castedCopy` won't work because of source being required. Also `setSource` is used to set sourceCallback.