### PR TITLE
Update requirements to Silverstripe/PHP supported versions (incl Silverstripe 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
 # silverstripe-dependentdropdownfield
 
-A SilverStripe dropdown field that has it's options populated via ajax, based on the value of the field it depends on.
+A SilverStripe dropdown field that has its options populated via ajax, based on the value of the field it depends on.
 
 ## Requirements
 
-SilverStripe 4
+SilverStripe 4 || 5
+
+## Installation
+
+```
+composer require sheadawson/silverstripe-dependentdropdownfield
+```
 
 ## Usage example
 
 ```php
-// 1. Create a callable function that returns an array of options for the DependentDropdownField. 
-// When the value of the field it depends on changes, this function is called passing the 
+// 1. Create a callable function that returns an array of options for the DependentDropdownField.
+// When the value of the field it depends on changes, this function is called passing the
 // updated value as the first parameter ($val)
-$datesSource = function($val) {	
+$datesSource = function($val) {
 	if ($val == 'one') {
 		// return appropriate options array if the value is one.
 	}
 	if ($val == 'two') {
 		// return appropriate options array if the value is two.
 	}
-}; 
+};
 
 $fields = FieldList::create(
-	// 2. Add your first field to your field list, 
+	// 2. Add your first field to your field list,
 	$fieldOne = DropdownField::create('FieldOne', 'Field One', ['one' => 'One', 'two' => 'Two']),
-	// 3. Add your DependentDropdownField, setting the source as the callable function 
+	// 3. Add your DependentDropdownField, setting the source as the callable function
 	// you created and setting the field it depends on to the appropriate field
 	DependentDropdownField::create('FieldTwo', 'Field Two', $datesSource)->setDepends($fieldOne)
 );

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         "issues": "https://github.com/sheadawson/silverstripe-dependentdropdownfield/issues"
     },
     "require": {
-        "php": ">=5.6",
-        "silverstripe/vendor-plugin": "^1.0",
-        "silverstripe/framework": "^4.0"
+        "php": ">=7.4",
+        "silverstripe/vendor-plugin": "^1 || ^2",
+        "silverstripe/framework": "^4.11 || ^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Forms/DependentDropdownField.php
+++ b/src/Forms/DependentDropdownField.php
@@ -6,7 +6,6 @@ use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Convert;
 use SilverStripe\ORM\Map;
 use SilverStripe\View\Requirements;
 use SilverStripe\Forms\FormField;
@@ -80,7 +79,7 @@ class DependentDropdownField extends DropdownField
             }
         }
 
-        $response->setBody(Convert::array2json($results));
+        $response->setBody(json_encode($results));
 
         return $response;
     }
@@ -154,7 +153,7 @@ class DependentDropdownField extends DropdownField
             return $source;
         }
     }
-    
+
      /**
      * @param \Closure $source
      * @return $this
@@ -174,7 +173,7 @@ class DependentDropdownField extends DropdownField
         if (!is_subclass_of(Controller::curr(), LeftAndMain::class)) {
             Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');
         }
-        
+
         Requirements::javascript(
             'sheadawson/silverstripe-dependentdropdownfield:client/js/dependentdropdownfield.js'
         );


### PR DESCRIPTION
## Silverstripe / PHP supported versions

* Silverstripe `4.11` is the lowest officially supported version.
* PHP `7.4` is the minimum supported PHP version for Silverstripe 4.

## `Convert` deprecation

No longer available in Silverstripe 5. Update usage of `Convert:array2json` to PHP's `json_encode()`.

## Testing Silverstripe `5.0.0-beta1`

Added the Taxonomies module to use as the source of my data.

```php
class Page extends SiteTree
{
    private static array $has_one = [
        'CountryTerm' => TaxonomyTerm::class,
        'CityTerm' => TaxonomyTerm::class,
    ];

    public function getCMSFields()
    {
        $fields = parent::getCMSFields();

        $countryTerms = TaxonomyTerm::get()->filter('ParentID', 0);

        $cityFromCountry = static function ($id) {
            return TaxonomyTerm::get()
                ->filter('ParentID', $id)
                ->map('ID', 'Name')
                ->toArray();
        };

        $fields->addFieldsToTab(
            'Root.Main',
            [
                $countryTermField = DropdownField::create(
                    'CountryTermID',
                    'Country Term',
                    $countryTerms
                ),
                $cityTermField = DependentDropdownField::create(
                    'CityTermID',
                    'City Term',
                    $cityFromCountry
                )->setDepends($countryTermField),
            ]
        );

        $countryTermField->setEmptyString('-- Select --');
        $cityTermField->setEmptyString('-- Select --');

        return $fields;
    }
}
```

### Results

Fields display correctly when there is no active selection:
<img width="1007" alt="Screen Shot 2023-02-20 at 9 04 46 AM" src="https://user-images.githubusercontent.com/505788/219972407-ade06107-ca96-4019-8bc3-4ea9d5c1deac.png">

Selection is made in the first field, the secondary field correctly updates with expected values:
<img width="1006" alt="Screen Shot 2023-02-20 at 9 04 58 AM" src="https://user-images.githubusercontent.com/505788/219972469-73101137-3c7f-4c24-a0fe-4296d0dcbeb0.png">

Both selections are made and saved. Refresh the edit form shows both values persisted:
<img width="1003" alt="Screen Shot 2023-02-20 at 9 05 08 AM" src="https://user-images.githubusercontent.com/505788/219972521-9a7cc182-97d3-4def-8c97-a4196fbddfc1.png">

Emptying the first field value correctly empties both fields:
<img width="1000" alt="Screen Shot 2023-02-20 at 9 07 26 AM" src="https://user-images.githubusercontent.com/505788/219972559-396a2083-b5a7-4bd3-8f00-7f1b85431c0c.png">
