### PR TITLE
Remove 'dist' from jquery-entwine requirement to allow front-end usage

### DIFF
--- a/src/Forms/DependentDropdownField.php
+++ b/src/Forms/DependentDropdownField.php
@@ -171,7 +171,7 @@ class DependentDropdownField extends DropdownField
     public function Field($properties = [])
     {
         if (!is_subclass_of(Controller::curr(), LeftAndMain::class)) {
-            Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');
+            Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/jquery.entwine.js');
         }
 
         Requirements::javascript(


### PR DESCRIPTION
The `dist` directory no longer exists under `jquery-entwine`, so this Requirement causes errors when it's used on the front-end:

```
if (!is_subclass_of(Controller::curr(), LeftAndMain::class)) {
  Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');
}
```

Removing the references to `dist` resolves the error:

```
if (!is_subclass_of(Controller::curr(), LeftAndMain::class)) {
  Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/jquery.entwine.js');
}
```
